### PR TITLE
fix create-site dependencies

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -30,9 +30,5 @@
   {
     "git_url": "https://github.com/frappe/insights",
     "branch": "main"
-  },
-  {
-    "git_url": "https://github.com/frappe/books",
-    "branch": "main"
   }
 ]

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -27,7 +27,9 @@ RUN useradd -ms /bin/bash frappe \
     gpg \
     # MariaDB
     mariadb-client \
+    libmariadb-dev \
     less \
+    pkg-config \
     # Postgres
     libpq-dev \
     postgresql-client \

--- a/pwd.yml
+++ b/pwd.yml
@@ -82,8 +82,7 @@ services:
         bench get-app https://github.com/frappe/studio;
         bench get-app https://github.com/frappe/wiki;
         bench get-app https://github.com/frappe/insights;
-        bench get-app https://github.com/frappe/books;
-        bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext,hrms,crm,helpdesk,drive,studio,wiki,insights,books --set-default frontend;
+        bench new-site --mariadb-user-host-login-scope='%' --admin-password=admin --db-root-username=root --db-root-password=admin --install-app erpnext,hrms,crm,helpdesk,drive,studio,wiki,insights --set-default frontend;
 
   db:
     image: mariadb:10.6


### PR DESCRIPTION
## Summary
- install pkg-config and libmariadb-dev for runtime builds
- stop installing books app during site creation

## Testing
- `pre-commit run --files images/production/Containerfile apps.json pwd.yml`


------
https://chatgpt.com/codex/tasks/task_b_68beb9d9e6f8832fa8265f3d9f455c90