### PR TITLE
fix: add mariadb dev compat

### DIFF
--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
     liblcms2-dev \
     libldap2-dev \
     libmariadb-dev \
+    libmariadb-dev-compat \
     libsasl2-dev \
     libtiff5-dev \
     libwebp-dev \

--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -91,6 +91,7 @@ RUN apt-get update \
     liblcms2-dev \
     libldap2-dev \
     libmariadb-dev \
+    libmariadb-dev-compat \
     libsasl2-dev \
     libtiff5-dev \
     libwebp-dev \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -28,6 +28,7 @@ RUN useradd -ms /bin/bash frappe \
     # MariaDB
     mariadb-client \
     libmariadb-dev \
+    libmariadb-dev-compat \
     less \
     pkg-config \
     # Postgres
@@ -85,6 +86,7 @@ RUN apt-get update \
     liblcms2-dev \
     libldap2-dev \
     libmariadb-dev \
+    libmariadb-dev-compat \
     libsasl2-dev \
     libtiff5-dev \
     libwebp-dev \


### PR DESCRIPTION
## Summary
- add libmariadb-dev-compat to bench image
- add libmariadb-dev-compat to production and custom images

## Testing
- `pre-commit run --files images/bench/Dockerfile images/production/Containerfile images/custom/Containerfile`

------
https://chatgpt.com/codex/tasks/task_b_68bec400b250832f8880bc35f696c80f