### PR TITLE
fix: correct pyenv variable for bench image

### DIFF
--- a/images/bench/Dockerfile
+++ b/images/bench/Dockerfile
@@ -110,7 +110,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git .pyenv \
     && pyenv install $PYTHON_VERSION \
     && PYENV_VERSION=$PYTHON_VERSION_V14 pip install --no-cache-dir virtualenv \
     && PYENV_VERSION=$PYTHON_VERSION pip install --no-cache-dir virtualenv \
-    && pyenv global $PYTHON_VERSION $PYTHON_VERSION_v14 \
+    && pyenv global $PYTHON_VERSION $PYTHON_VERSION_V14 \
     && sed -Ei -e '/^([^#]|$)/ {a export PYENV_ROOT="/home/frappe/.pyenv" a export PATH="$PYENV_ROOT/bin:$PATH" a ' -e ':a' -e '$!{n;ba};}' ~/.profile \
     && echo 'eval "$(pyenv init --path)"' >>~/.profile \
     && echo 'eval "$(pyenv init -)"' >>~/.bashrc


### PR DESCRIPTION
## Summary
- fix pyenv global call to use correct PYTHON_VERSION_V14 variable

## Testing
- `pre-commit run --files images/bench/Dockerfile`
- `pytest` *(fails: KeyError: 'FRAPPE_VERSION')*
- `docker build -t bench_local -f images/bench/Dockerfile images/bench` *(fails: Cannot connect to Docker daemon / insufficient privileges)*

------
https://chatgpt.com/codex/tasks/task_b_68bf21541aac832fb94ca29e5c778dc1