### PR TITLE
chore: enforce strict error handling in nginx entrypoint

### DIFF
--- a/resources/nginx-entrypoint.sh
+++ b/resources/nginx-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Set variables that do not exist
 if [[ -z "$BACKEND" ]]; then


### PR DESCRIPTION
## Summary
- add `set -euo pipefail` to nginx entrypoint script for stricter error handling

## Testing
- `BACKEND=a SOCKETIO=b UPSTREAM_REAL_IP_ADDRESS=c UPSTREAM_REAL_IP_HEADER=d UPSTREAM_REAL_IP_RECURSIVE=e FRAPPE_SITE_NAME_HEADER=f PROXY_READ_TIMEOUT=1 CLIENT_MAX_BODY_SIZE=1 bash resources/nginx-entrypoint.sh >/tmp/script.log && echo success || echo failure; cat /tmp/script.log`
- `FRAPPE_VERSION=v14 pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_b_68bf23118830832fa274f0e8f166d13a