### PR TITLE
feat: pin frappe-bench version

### DIFF
--- a/images/custom/Containerfile
+++ b/images/custom/Containerfile
@@ -59,7 +59,7 @@ RUN useradd -ms /bin/bash frappe \
     # Clean up
     && rm -rf /var/lib/apt/lists/* \
     && rm -fr /etc/nginx/sites-enabled/default \
-    && pip3 install frappe-bench \
+    && pip3 install --no-cache-dir frappe-bench==5.25.9 \
     # Fixes for non-root nginx and logs to stdout
     && sed -i '/user www-data/d' /etc/nginx/nginx.conf \
     && ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log \

--- a/images/production/Containerfile
+++ b/images/production/Containerfile
@@ -59,7 +59,7 @@ RUN useradd -ms /bin/bash frappe \
     # Clean up
     && rm -rf /var/lib/apt/lists/* \
     && rm -fr /etc/nginx/sites-enabled/default \
-    && pip3 install frappe-bench \
+    && pip3 install --no-cache-dir frappe-bench==5.25.9 \
     # Fixes for non-root nginx and logs to stdout
     && sed -i '/user www-data/d' /etc/nginx/nginx.conf \
     && ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log \


### PR DESCRIPTION
## Summary
- pin frappe-bench to 5.25.9 in custom and production images

## Testing
- `pre-commit run --files images/custom/Containerfile images/production/Containerfile`
- `bench --version`
- ⚠️ `podman build --target base -t custom-base-test -f images/custom/Containerfile .` (operation not permitted)


------
https://chatgpt.com/codex/tasks/task_b_68bf2406d708832fadc3678cc32b4a5e