### PR TITLE
Add MariaDB user host login scope flag for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def frappe_site(compose: Compose):
     site_name = "tests.localhost"
     compose.bench(
         "new-site",
-        # TODO: change to --mariadb-user-host-login-scope=%
+        "--mariadb-user-host-login-scope=%",
         "--no-mariadb-socket",
         "--db-root-password=123",
         "--admin-password=admin",
@@ -95,7 +95,7 @@ def erpnext_site(compose: Compose):
     site_name = "test-erpnext-site.localhost"
     args = [
         "new-site",
-        # TODO: change to --mariadb-user-host-login-scope=%
+        "--mariadb-user-host-login-scope=%",
         "--no-mariadb-socket",
         "--db-root-password=123",
         "--admin-password=admin",


### PR DESCRIPTION
## Summary
- allow remote MariaDB connections when creating test sites

## Testing
- `pytest tests/test_frappe_docker.py::test_endpoints -q` *(fails: docker compose returned exit status 125)*
- `pytest tests/test_frappe_docker.py::TestErpnext::test_endpoints -q` *(fails: docker compose returned exit status 125)*

------
https://chatgpt.com/codex/tasks/task_b_68bf25b26278832fa92a7854f5ee159d